### PR TITLE
[CHANGE] Worker Shutdown should be a debug log not a info

### DIFF
--- a/killstats/tasks.py
+++ b/killstats/tasks.py
@@ -49,7 +49,7 @@ def run_zkb_redis():
             break
 
         if cache.get(f"{__title__.upper()}_WORKER_SHUTDOWN"):
-            logger.info("Worker shutdown detected; stopping zKB RedisQ processing")
+            logger.debug("Worker shutdown detected; stopping zKB RedisQ processing")
             break
 
         if not killmail:


### PR DESCRIPTION
## Description

Please include a summary of the changes and the related issue number (if applicable).
### Changed
- Worker Shutdown should be a debug log not a info

## Type of Changes
Please select the type of changes made in this pull request:
- [x] Bug Fix (non-breaking change which fixes an Issue)
- [ ] New Feature (non-breaking change)
- [ ] Other (please specify):

## Checklist
Please ensure the following before submitting your pull request:
- [x] I have read the [contributing guidelines](https://github.com/Geuthur/aa-killstats/blob/master/CODE_OF_CONDUCT.md).
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] All new and existing tests passed.
