### PR TITLE
[RELEASE] v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ Section Order:
 ### Removed
 -->
 
+## [1.0.1] - 2025-11-13
+
+### Changed
+
+- Updated dependencies
+  - `allianceauth-app-utils` to `>=2b2`
+  - `allianceauth` to `>=4.10,<5`
+  - `django-esi` to `8,<9`
+  - `django-eveuniverse` to `>=1.6`
+
+### Removed
+
+- csrf arg from `django-ninja`
+- `django-ninja` dependency pin `<1.5`
+
 ## [1.0.0] - 13.11.2025
 
 ### Added

--- a/killstats/__init__.py
+++ b/killstats/__init__.py
@@ -1,6 +1,6 @@
 """Initialize the app"""
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 __title__ = "Killstats"
 
 __package_name__ = "aa-killstats"

--- a/killstats/locale/django.pot
+++ b/killstats/locale/django.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: AA Killstats 1.0.0\n"
+"Project-Id-Version: AA Killstats 1.0.1\n"
 "Report-Msgid-Bugs-To: https://github.com/Geuthur/aa-killstats/issues\n"
-"POT-Creation-Date: 2025-11-13 22:12+0100\n"
+"POT-Creation-Date: 2025-11-13 23:36+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,11 +35,11 @@ dynamic = [
 ]
 dependencies = [
     "allianceauth>=4.10,<5",
-    "allianceauth-app-utils>=1.27",
+    "allianceauth-app-utils>=2b2",
     "dacite",
-    "django-esi>=8b2",
-    "django-eveuniverse>=1.5.7",
-    "django-ninja<1.5",
+    "django-esi>=8,<9",
+    "django-eveuniverse>=1.6",
+    "django-ninja",
 ]
 optional-dependencies.tests-allianceauth-latest = [
     "coverage",


### PR DESCRIPTION
## [1.0.1] - 2025-11-13

### Changed

- Updated dependencies
  - `allianceauth-app-utils` to `>=2b2`
  - `allianceauth` to `>=4.10,<5`
  - `django-esi` to `8,<9`
  - `django-eveuniverse` to `>=1.6`

### Removed

- csrf arg from `django-ninja`
- `django-ninja` dependency pin `<1.5`